### PR TITLE
Implement FetchGamesUseCase

### DIFF
--- a/lib/data/models/game_dto.dart
+++ b/lib/data/models/game_dto.dart
@@ -1,0 +1,13 @@
+class GameDto {
+  final String pgn;
+  final int endTime;
+
+  GameDto({required this.pgn, required this.endTime});
+
+  factory GameDto.fromJson(Map<String, dynamic> json) {
+    return GameDto(
+      pgn: json['pgn'] as String,
+      endTime: json['end_time'] as int,
+    );
+  }
+}

--- a/lib/data/sources/chess_api.dart
+++ b/lib/data/sources/chess_api.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/game_dto.dart';
+
+class ChessApi {
+  final http.Client _client;
+
+  ChessApi({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<List<GameDto>> fetchMonthlyArchive({
+    required String username,
+    required int year,
+    required int month,
+  }) async {
+    final url = Uri.parse(
+        'https://api.chess.com/pub/player/$username/games/$year/${month.toString().padLeft(2, '0')}');
+    final response = await _client.get(url);
+    if (response.statusCode != 200) {
+      throw http.ClientException('Failed to load games', url);
+    }
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final games = (data['games'] as List)
+        .map((e) => GameDto.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return games;
+  }
+}

--- a/lib/domain/entities/pgn_game.dart
+++ b/lib/domain/entities/pgn_game.dart
@@ -1,0 +1,11 @@
+import 'package:equatable/equatable.dart';
+
+class PgnGame extends Equatable {
+  final String pgn;
+  final DateTime endTime;
+
+  const PgnGame({required this.pgn, required this.endTime});
+
+  @override
+  List<Object?> get props => [pgn, endTime];
+}

--- a/lib/domain/usecases/fetch_games_usecase.dart
+++ b/lib/domain/usecases/fetch_games_usecase.dart
@@ -1,0 +1,25 @@
+import '../../data/sources/chess_api.dart';
+import '../../data/models/game_dto.dart';
+import '../entities/pgn_game.dart';
+
+class FetchGamesUseCase {
+  final ChessApi api;
+
+  FetchGamesUseCase(this.api);
+
+  Future<List<PgnGame>> call({
+    required String username,
+    required int year,
+    required int month,
+  }) async {
+    final dtos = await api.fetchMonthlyArchive(
+        username: username, year: year, month: month);
+    final games = dtos
+        .map((dto) => PgnGame(
+            pgn: dto.pgn,
+            endTime: DateTime.fromMillisecondsSinceEpoch(dto.endTime * 1000)))
+        .toList();
+    games.sort((a, b) => b.endTime.compareTo(a.endTime));
+    return games;
+  }
+}

--- a/lib/presentation/cubit/home_cubit.dart
+++ b/lib/presentation/cubit/home_cubit.dart
@@ -1,0 +1,20 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../domain/entities/pgn_game.dart';
+import '../../domain/usecases/fetch_games_usecase.dart';
+
+part 'home_state.dart';
+
+class HomeCubit extends Cubit<HomeState> {
+  final FetchGamesUseCase _fetchGames;
+
+  HomeCubit(this._fetchGames) : super(HomeInitial());
+
+  Future<void> fetch(String username, int year, int month) async {
+    emit(HomeFetching());
+    final games =
+        await _fetchGames(username: username, year: year, month: month);
+    emit(HomeLoaded(games));
+  }
+}

--- a/lib/presentation/cubit/home_state.dart
+++ b/lib/presentation/cubit/home_state.dart
@@ -1,0 +1,24 @@
+part of 'home_cubit.dart';
+
+abstract class HomeState extends Equatable {
+  const HomeState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class HomeInitial extends HomeState {}
+
+class HomeFetching extends HomeState {}
+
+class HomeLoaded extends HomeState {
+  final List<PgnGame> games;
+  const HomeLoaded(this.games);
+
+  @override
+  List<Object?> get props => [games];
+}
+
+class HomePagination extends HomeLoaded {
+  const HomePagination(List<PgnGame> games) : super(games);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,11 @@ dependencies:
   flutter:
     sdk: flutter
 
+  http: ^0.13.6
+  equatable: ^2.0.5
+  bloc: ^8.1.2
+  flutter_bloc: ^8.1.3
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
@@ -38,6 +43,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+  mocktail: ^1.0.3
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/fetch_games_usecase_test.dart
+++ b/test/fetch_games_usecase_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:chess_engine/data/sources/chess_api.dart';
+import 'package:chess_engine/domain/usecases/fetch_games_usecase.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  group('FetchGamesUseCase', () {
+    late MockHttpClient client;
+    late ChessApi api;
+    late FetchGamesUseCase useCase;
+
+    setUp(() {
+      client = MockHttpClient();
+      api = ChessApi(client: client);
+      useCase = FetchGamesUseCase(api);
+    });
+
+    test('parses and sorts games by end_time desc', () async {
+      final fixture =
+          File('test/fixtures/hikaru_2025_05.json').readAsStringSync();
+      when(() => client.get(any())).thenAnswer(
+        (_) async => http.Response(fixture, 200),
+      );
+
+      final games =
+          await useCase(username: 'hikaru', year: 2025, month: 5);
+
+      expect(games, hasLength(2));
+      expect(games.first.endTime.isAfter(games.last.endTime), isTrue);
+    });
+  });
+}

--- a/test/fixtures/hikaru_2025_05.json
+++ b/test/fixtures/hikaru_2025_05.json
@@ -1,0 +1,12 @@
+{
+  "games": [
+    {
+      "pgn": "[Event \"Live Chess\"]\n[Site \"Chess.com\"]\n[Date \"2025.05.15\"]\n[Round \"-\"]\n[White \"Hikaru\"]\n[Black \"Opponent1\"]\n[Result \"1-0\"]\n",
+      "end_time": 1747353600
+    },
+    {
+      "pgn": "[Event \"Live Chess\"]\n[Site \"Chess.com\"]\n[Date \"2025.05.10\"]\n[Round \"-\"]\n[White \"Hikaru\"]\n[Black \"Opponent2\"]\n[Result \"0-1\"]\n",
+      "end_time": 1746902400
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add models and entity for Chess.com API games
- implement ChessApi data source
- create FetchGamesUseCase with sorting logic
- introduce HomeCubit and states
- add unit test using Hikaru fixture

## Testing Steps
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart tool/engine_smoke_test.dart` *(fails: command not found)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68409ea579d8832dba945ca64d2c3751